### PR TITLE
Исправление ошибки с tag в шаблоне Word

### DIFF
--- a/MathCore.OpenXML/MathCore.OpenXML.csproj
+++ b/MathCore.OpenXML/MathCore.OpenXML.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <ExplicitUsing>Enabled</ExplicitUsing>
-    <Version>0.0.6</Version>
+    <Version>0.0.6.1</Version>
     <PackageReleaseNotes>
       Изменён механизм заполнения полей шаблона Word
     </PackageReleaseNotes>

--- a/MathCore.OpenXML/WordProcessing/Extensions/Word/ExetnsionsOpenXmlPackage.cs
+++ b/MathCore.OpenXML/WordProcessing/Extensions/Word/ExetnsionsOpenXmlPackage.cs
@@ -14,7 +14,7 @@ public static class ExetnsionsOpenXmlPackage
 
         foreach (var (tag, field) in fields)
         {
-            var alias = field.GetFirstChild<SdtProperties>()?.GetFirstChild<SdtAlias>()?.Val?.Value;
+            var alias = field.GetAlias();
             var text = field.InnerText;
 
             yield return (tag, alias, text);

--- a/MathCore.OpenXML/WordProcessing/Extensions/Word/ExtensionsSdt.cs
+++ b/MathCore.OpenXML/WordProcessing/Extensions/Word/ExtensionsSdt.cs
@@ -47,13 +47,13 @@ public static class ExtensionsSdt
             ?? throw new InvalidOperationException("Не найден узел с параметрами");
 
         var tag = properties.Elements<Tag>().FirstOrDefault();
-        return tag?.Val?.Value;
+        return tag?.Val?.Value?.Trim();
     }
 
     public static string? GetAlias(this SdtElement run)
     {
         var properties = run.GetFirstChild<SdtProperties>()!;
-        var aliace = properties.GetFirstChild<SdtAlias>()!.Val?.Value;
+        var aliace = properties.GetFirstChild<SdtAlias>()?.Val?.Value?.Trim();
         return aliace;
     }
 

--- a/MathCore.OpenXML/WordProcessing/Extensions/Word/ExtensionsWordprocessingDocument.cs
+++ b/MathCore.OpenXML/WordProcessing/Extensions/Word/ExtensionsWordprocessingDocument.cs
@@ -19,7 +19,7 @@ public static class ExtensionsWordprocessingDocument
 
         foreach (var (tag, field) in document_fields)
         {
-            var alias = field.GetFirstChild<SdtProperties>()?.GetFirstChild<SdtAlias>()?.Val?.Value;
+            var alias = field.GetAlias();
             var text = field.InnerText;
 
             yield return (tag, alias, text);

--- a/MathCore.OpenXML/WordProcessing/Templates/WordTemplate.cs
+++ b/MathCore.OpenXML/WordProcessing/Templates/WordTemplate.cs
@@ -52,7 +52,7 @@ public class WordTemplate
 
         foreach (var (tag, field) in document_fields)
         {
-            var alias = field.GetFirstChild<SdtProperties>()?.GetFirstChild<SdtAlias>()?.Val?.Value;
+            var alias = field.GetAlias();
             var text = field.InnerText;
 
             yield return new(text)


### PR DESCRIPTION
Если в tag в начале и в конце есть пробелы, то они теперь будут отброшены автоматически.